### PR TITLE
Add config 'unsafe' to allow HTML enbedding

### DIFF
--- a/lib/Template/Plugin/CommonMark.pm
+++ b/lib/Template/Plugin/CommonMark.pm
@@ -30,6 +30,7 @@ sub filter {
     $config->{normalize} and $opt |= CommonMark::OPT_NORMALIZE;
     $config->{validate_utf8} and $opt |= CommonMark::OPT_VALIDATE_UTF8;
     $config->{smart} and $opt |= CommonMark::OPT_SMART;
+    $config->{unsafe} and $opt |= CommonMark::OPT_UNSAFE;
 
     CommonMark->markdown_to_html($text, $opt)
 }

--- a/t/01-cmark.t
+++ b/t/01-cmark.t
@@ -76,6 +76,42 @@ EO_HTML
 'Code block',
 ],
 
+[
+<<'EO_TMPL',
+[% USE CommonMark %]
+[% FILTER cmark %]
+Foo
+
+<span>Bar</span>
+[% END %]
+EO_TMPL
+
+<<EO_HTML,
+<p>Foo</p>
+<p><!-- raw HTML omitted -->Bar<!-- raw HTML omitted --></p>
+EO_HTML
+
+'Safe, no embedded HTML',
+],
+
+  [
+<<'EO_TMPL',
+[% USE CommonMark(unsafe=1) %]
+[% FILTER cmark %]
+Foo
+
+<span>Bar</span>
+[% END %]
+EO_TMPL
+
+<<EO_HTML,
+<p>Foo</p>
+<p><span>Bar</span></p>
+EO_HTML
+
+'Embed HTML',
+],
+
 );
 
 for my $case ( @cases ) {


### PR DESCRIPTION
Sometimes it is desired to embed HTML in markdown source. E.g. when you PROCESS other templates that produce HTML.

This patch adds the config option `unsafe` to add `OPT_UNSAFE` to the CommonMark options.